### PR TITLE
Feature: Dual Authorize

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -359,21 +359,18 @@ fn login_authorize(
 ) -> impl Filter<Extract = (PodSyncAuthed<true>,), Error = warp::Rejection> + Clone {
     warp::path::param::<String>()
         .and(warp::header("authorization"))
-        .and(warp::cookie::optional(COOKIE_NAME))
-        .and_then(
-            move |username: String, auth: BasicAuth, session_id: Option<SessionId>| {
-                let podsync = Arc::clone(&podsync);
-                async move {
-                    let username = username_fmt.convert(&username)?;
-                    let auth = auth.with_path_username(&username)?;
-                    podsync
-                        .login(auth, session_id)
-                        .await?
-                        .with_user(&username)
-                        .map_err(warp::reject::custom)
-                }
-            },
-        )
+        .and_then(move |username: String, auth: BasicAuth| {
+            let podsync = Arc::clone(&podsync);
+            async move {
+                let username = username_fmt.convert(&username)?;
+                let auth = auth.with_path_username(&username)?;
+                podsync
+                    .login(auth, None)
+                    .await?
+                    .with_user(&username)
+                    .map_err(warp::reject::custom)
+            }
+        })
 }
 
 fn authorize(

--- a/src/main.rs
+++ b/src/main.rs
@@ -313,7 +313,7 @@ pub struct QuerySince {
     since: crate::time::Timestamp,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug)]
 enum UsernameFormat {
     Name,
     NameJson,

--- a/src/main.rs
+++ b/src/main.rs
@@ -366,8 +366,7 @@ fn login_authorize(
                 let auth = auth.with_path_username(&username)?;
                 podsync
                     .login(auth, None)
-                    .await?
-                    .with_user(&username)
+                    .await
                     .map_err(warp::reject::custom)
             }
         })

--- a/src/podsync.rs
+++ b/src/podsync.rs
@@ -67,7 +67,7 @@ impl PodSync {
         self: &Arc<Self>,
         auth_attempt: AuthAttempt,
         client_session_id: Option<SessionId>,
-    ) -> Result<PodSyncAuthed> {
+    ) -> Result<PodSyncAuthed<true>> {
         let username = auth_attempt.user();
 
         let user = query_as!(
@@ -204,10 +204,6 @@ impl PodSync {
 }
 
 impl PodSyncAuthed {
-    pub fn session_id(&self) -> &SessionId {
-        &self.session_id
-    }
-
     pub fn with_user(self, username: &str) -> Result<PodSyncAuthed<true>> {
         if username == self.username {
             Ok(PodSyncAuthed {
@@ -246,6 +242,10 @@ impl PodSyncAuthed<true> {
             error!("error updating session_id: {e:?}");
             Error::Internal
         })
+    }
+
+    pub fn session_id(&self) -> &SessionId {
+        &self.session_id
     }
 
     pub async fn devices(&self) -> Result<Vec<DeviceAndSub>> {


### PR DESCRIPTION
Allows for both authorizing via cookies and via user:pass login on each of the end points.

I saw 2 options of implementing this; either via filters, or (probably) via normal methods in the 'then' closure. The latter should allow for the endpoints to keep their full path as one line.

I chose for the former however; since in my mind it makes for cleaner code.

Any comments?