### PR TITLE
Allow for building with rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,14 @@ pretty_env_logger = "0.4.0"
 cookie = "0.17.0"
 warp = "0.3.3"
 
-sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "sqlite", "time", "offline"]}
+sqlx = { version = "0.6.2", features = ["sqlite", "time", "offline"]}
 # sqlx-cli
 
 base64_light = "0.1.5"
 sha256 = "1.1.2"
 uuid = { version = "1.3.0", features = ["v4"] }
+
+[features]
+default = ["native-tls"]
+native-tls = ["sqlx/runtime-tokio-native-tls"]
+rustls = ["sqlx/runtime-tokio-rustls"]


### PR DESCRIPTION
This still has native-tls as default.

Rustls is easier when cross-compiling since it doesn't rely on openssl.