### PR TITLE
Extremely quick fix to add-user script

### DIFF
--- a/scripts/add-user.sh
+++ b/scripts/add-user.sh
@@ -32,5 +32,5 @@ hash=$(printf '%s' "$pass" | sha_hash)
 
 sqlite3 pod.sql <<!
 INSERT INTO users
-VALUES ("$user", "$hash", NULL);
+VALUES ('$user', '$hash', NULL);
 !


### PR DESCRIPTION
This script broke in my system (Fedora 40 Server) when I tried to add a user to the db.

TIL that apparently sqlite3 considers double quotes to be column names (for what I'm sure is a completely justifiable reason :)) )
Extremely simple, just need to replace with single quotes, shouldn't break anything else.

Btw this is the best solution for podcast syncing I've used, your work is absolutely amazing!