### PR TITLE
Implement new `data_dir` parameter to customize data storage location

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -1,6 +1,6 @@
 use std::{
     net::{AddrParseError, IpAddr, SocketAddr},
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 use clap::Parser;
@@ -48,7 +48,7 @@ impl Args {
         self.version
     }
 
-    pub fn data_dir(&self) -> Option<PathBuf> {
-        self.data_dir.clone()
+    pub fn data_dir(&self) -> Option<&Path> {
+        self.data_dir.as_deref()
     }
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -17,7 +17,7 @@ pub struct Args {
     #[arg(short, long)]
     address: Option<String>,
 
-    /// The location of the data directory. By default 
+    /// The location of the data directory. By default
     /// this is the current working directory.
     #[arg(short, long)]
     data_dir: Option<PathBuf>,

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,4 +1,7 @@
-use std::{net::{AddrParseError, IpAddr, SocketAddr}, path::PathBuf};
+use std::{
+    net::{AddrParseError, IpAddr, SocketAddr},
+    path::PathBuf,
+};
 
 use clap::Parser;
 
@@ -43,5 +46,9 @@ impl Args {
 
     pub fn show_version(&self) -> bool {
         self.version
+    }
+
+    pub fn data_dir(&self) -> Option<PathBuf> {
+        self.data_dir.clone()
     }
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,4 +1,4 @@
-use std::net::{AddrParseError, IpAddr, SocketAddr};
+use std::{net::{AddrParseError, IpAddr, SocketAddr}, path::PathBuf};
 
 use clap::Parser;
 
@@ -13,6 +13,11 @@ pub struct Args {
     /// podsync will listen just on the IPv4 loopback.
     #[arg(short, long)]
     address: Option<String>,
+
+    /// The location of the data directory. By default 
+    /// this is the current working directory.
+    #[arg(short, long)]
+    data_dir: Option<PathBuf>,
 
     /// The port podsync listens on.
     #[arg(short, long, default_value_t = 80)]

--- a/src/backend/backend_file.rs
+++ b/src/backend/backend_file.rs
@@ -24,12 +24,13 @@ pub struct Backend {
     root: PathBuf,
 }
 
-pub async fn init() {}
+// Change introduced to match function signature with backend_sql
+pub async fn init(data_dir: &PathBuf) {}
 
 impl Backend {
-    pub async fn new() -> Self {
+    pub async fn new(path: &PathBuf) -> Self {
         Self {
-            root: PathBuf::from("."),
+            root: path.to_path_buf(),
         }
     }
 }

--- a/src/backend/backend_file.rs
+++ b/src/backend/backend_file.rs
@@ -4,7 +4,7 @@
 use std::collections::HashSet;
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, ErrorKind, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use log::{error, info, warn};
 
@@ -25,7 +25,7 @@ pub struct Backend {
 }
 
 impl Backend {
-    pub async fn new(path: &PathBuf) -> Self {
+    pub async fn new(path: &Path) -> Self {
         Self {
             root: path.to_path_buf(),
         }

--- a/src/backend/backend_file.rs
+++ b/src/backend/backend_file.rs
@@ -24,9 +24,6 @@ pub struct Backend {
     root: PathBuf,
 }
 
-// Change introduced to match function signature with backend_sql
-pub async fn init(data_dir: &PathBuf) {}
-
 impl Backend {
     pub async fn new(path: &PathBuf) -> Self {
         Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(feature = "backend-sql", allow(unexpected_cfgs))]
 #![cfg_attr(not(feature = "backend-sql"), deny(unexpected_cfgs))]
 
-use std::{future::Future, sync::Arc};
+use std::{future::Future, path::PathBuf, sync::Arc};
 
 use ::time::ext::NumericalDuration;
 use cookie::{Cookie, SameSite};
@@ -60,9 +60,13 @@ async fn main() {
         println!("PodSync {}", env!("CARGO_PKG_VERSION"));
         return;
     }
-
-    backend::init().await;
-    let backend = Backend::new().await;
+    let mut data_dir = if let Some(path) = args.data_dir() {
+        path
+    } else {
+        PathBuf::from(".")
+    };
+    backend::init(&data_dir).await;
+    let backend = Backend::new(&mut data_dir).await;
 
     let secure = args.secure();
     let podsync = Arc::new(PodSync::new(backend));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(feature = "backend-sql", allow(unexpected_cfgs))]
 #![cfg_attr(not(feature = "backend-sql"), deny(unexpected_cfgs))]
 
-use std::{future::Future, path::PathBuf, sync::Arc};
+use std::{future::Future, path::Path, sync::Arc};
 
 use ::time::ext::NumericalDuration;
 use cookie::{Cookie, SameSite};
@@ -60,12 +60,8 @@ async fn main() {
         println!("PodSync {}", env!("CARGO_PKG_VERSION"));
         return;
     }
-    let mut data_dir = if let Some(path) = args.data_dir() {
-        path
-    } else {
-        PathBuf::from(".")
-    };
-    backend::init(&data_dir).await;
+    let mut data_dir = args.data_dir().unwrap_or_else(|| Path::new("."));
+
     let backend = Backend::new(&mut data_dir).await;
 
     let secure = args.secure();

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,9 +60,9 @@ async fn main() {
         println!("PodSync {}", env!("CARGO_PKG_VERSION"));
         return;
     }
-    let mut data_dir = args.data_dir().unwrap_or_else(|| Path::new("."));
+    let data_dir = args.data_dir().unwrap_or_else(|| Path::new("."));
 
-    let backend = Backend::new(&mut data_dir).await;
+    let backend = Backend::new(&data_dir).await;
 
     let secure = args.secure();
     let podsync = Arc::new(PodSync::new(backend));


### PR DESCRIPTION
Like title suggests, this PR implements a new parameter `data_dir: Option<PathBuf>` to allow the end user to choose a directory they would like the database to be stored in. _I'm not very good at wrestling with the Rust borrow checker so this may not be the most efficient implementation._ 

I found just putting `pod.sql` in the working directory wherever it was placed, as it was originally done, slightly annoying, so this is my crude solution. 

The CI workflow should pass without issues. I checked with my AntennaPod and a local server and it is running fine.

